### PR TITLE
Switch to mpich for Linux

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 openmpi:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@
 # msmpi is not in the global pinning
 # on macos, mpich MPI_Finalize hangs for all versions > 4.0.3 (tested up to 4.3.0)
 mpi:
-  - openmpi # [linux]
+  - mpich # [linux]
   - mpich =4.0.3 # [osx]
   - msmpi =10.1.1 # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://github.com/KhiopsML/khiops/archive/refs/tags/{{ khiops_version }}.tar.gz
   sha256: 2321837b22b84567e7b3fd08a7963d540f4e03ec488fb0ebdca5ecc14bf9ef01
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
There is an issue on Linux with openmpi 5.0.8: "Error: Unable to get the user home directory" It seems to occur when the home directory is not set

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
